### PR TITLE
Bump version to 0.0.9 ( published to npm )

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/eth-relay",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A library encapsulating various transaction relayers on EVM chains",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
Bump version to 0.0.9 ( published to npm )
https://www.npmjs.com/package/@civic/eth-relay/v/0.0.9